### PR TITLE
Step 1: typing cid.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,3 +87,6 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+types:
+	mypy multiformats_cid --strict

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ coverage==4.5.4
 cryptography==3.3.2
 flake8==3.7.8
 hypothesis==5.33.2
+mypy==0.991
 pytest-cov==2.10.1
 pytest-runner==5.1
 pytest==4.6.5


### PR DESCRIPTION
This adds all the relevant type annotations to make this project "typed". The only remaining tasks are to lift those 4 `# type: ignore` in the dependencies, I will try and open relevant PRs to each project (depending on how big they are). 

This also adds an empty `py.typed` file to the module root.

#### Follow up

Go deep into the dependency rabbit hole, do the same kinda thing and comeback to lift those ignored types. 

### Test Plan
Also added here is a type checker to the Makefile (can be run with `make types`) which runs 

Closes #1 

```
mypy multiformats_cid --strict
```

All existing unit tests appear to be passing.