### PR TITLE
Fix setup.cfg file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,4 +36,4 @@ exclude_lines =
 	if __name__ == .__main__.:
 
 [options.package_data]
-cid = py.typed
+multiformats_cid = py.typed


### PR DESCRIPTION
Closes #4

We can see that [this build](https://github.com/cowprotocol/dune-bridge/actions/runs/3508437894/jobs/5876840268) is failing types (although it shouldn't).

This is because the py.typed file does not exist in the package:

![Screenshot 2022-11-20 at 15 56 04](https://user-images.githubusercontent.com/11778116/202909189-e22a6910-cc2a-4248-ad95-14094c9be09d.png)

I can confirm that simply adding an empty file `py.typed` does satisfy mypy, we just need to make sure it gets included in the build when published. Might be worth checking this locally first.

Note that CI is failing in the same way that it is on `master` (this PR did not introduce that issue).

### Test Plan

Run the build process (not sure exactly how its done in this project, but) something like this:
```
python -m build
```

Watch the logs (or check the contents of the `dist/` directory that is written -- for `py.typed` sitting along side with `cid.py`

If its there, then Ok to publish!


